### PR TITLE
Update ansible-lint to current Galaxy version

### DIFF
--- a/.azure-pipelines/commands/lint.sh
+++ b/.azure-pipelines/commands/lint.sh
@@ -3,13 +3,13 @@
 set -o pipefail -eux
 
 # This is aligned with the galaxy-importer used by AH.
-# Need to pin to the released tag at.
-# https://github.com/ansible/galaxy_ng/blob/master/requirements/requirements.common.txt
-#
-# The galaxy_ng_commit from can be used to find the specific commit to check.
+# Check what galaxy_importer_version is used in the galaxy project at
 # https://galaxy.ansible.com/api/
+
+# Then check the ansible-lint upper bound at
+# https://github.com/ansible/galaxy-importer/blob/v${VERSION}/setup.cfg
+
 python -m pip install \
-    'ansible-lint==24.12.2' \
-    'ansible-compat==24.10.0'
+    'ansible-lint==25.1.2'
 
 ansible-lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Created by https://www.gitignore.io/api/git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
 # Edit at https://www.gitignore.io/?templates=git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
 
@@ -388,6 +387,9 @@ $RECYCLE.BIN/
 
 # Changelog cache files
 changelogs/.plugin-cache.yaml
+
+# Ansible dev tools
+.ansible/
 
 # ansible-test ignores
 tests/integration/inventory*


### PR DESCRIPTION
##### SUMMARY
Update the ansible-lint version to the current one used in Galaxy/AH.