### PR TITLE
web_app_pool: fix schedule attribute to support array

### DIFF
--- a/changelogs/fragments/48-web-app-pool-schedule.yml
+++ b/changelogs/fragments/48-web-app-pool-schedule.yml
@@ -1,3 +1,2 @@
 bugfixes:
   - web_app_pool - Fix ``attributes`` to accept entries with values of Array (https://github.com/ansible-collections/microsoft.iis/issues/48).
-

--- a/changelogs/fragments/48-web-app-pool-schedule.yml
+++ b/changelogs/fragments/48-web-app-pool-schedule.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - web_app_pool - Fix ``attributes`` to accept entries with values of Array (https://github.com/ansible-collections/microsoft.iis/issues/48).
+

--- a/plugins/modules/web_app_pool.ps1
+++ b/plugins/modules/web_app_pool.ps1
@@ -61,13 +61,8 @@ Function Convert-CollectionToList($collection) {
             $list += $entry.Value.ToString()
         }
     }
-    elseif ($collection[0] -as [System.String]) {
-        try {
-            $list = [System.String[]]$collection
-        }
-        catch {
-            $module.FailJson("Failed to read $($attribute_key): $($_.Exception.Message)", $_)
-        }
+    elseif ($collection -as [System.TimeSpan[]]) {
+        $list = [System.TimeSpan[]]$collection
     }
     elseif ($collection -isnot [Array]) {
         $list += $collection

--- a/plugins/modules/web_app_pool.ps1
+++ b/plugins/modules/web_app_pool.ps1
@@ -61,6 +61,14 @@ Function Convert-CollectionToList($collection) {
             $list += $entry.Value.ToString()
         }
     }
+    elseif ($collection[0] -as [System.String]) {
+        try {
+            $list = [System.String[]]$collection
+        }
+        catch {
+            $module.FailJson("Failed to read $($attribute_key): $($_.Exception.Message)", $_)
+        }
+    }
     elseif ($collection -isnot [Array]) {
         $list += $collection
     }

--- a/tests/integration/targets/web_app_pool/tasks/tests.yml
+++ b/tests/integration/targets/web_app_pool/tasks/tests.yml
@@ -339,7 +339,7 @@
     name: '{{test_iis_webapppool_name}}'
     state: present
     attributes:
-      recycling.periodicRestart.schedule: "00:10:00,10:10:00"
+      recycling.periodicRestart.schedule: ["00:10:00","10:10:00"]
   register: collection_change_check
   check_mode: yes
 
@@ -355,15 +355,35 @@
     - collection_change_check is changed
     - collection_change_result_check.stdout == ""
 
-- name: set web pool attribute that is a collection
+- name: set web pool attribute that is a collection (string)
   web_app_pool:
     name: '{{test_iis_webapppool_name}}'
     state: present
     attributes:
-      recycling.periodicRestart.schedule: "00:10:00,10:10:00"
+      recycling.periodicRestart.schedule: "01:10:00,11:10:00"
   register: collection_change
 
-- name: get result of set web pool attribute that is a collection
+- name: get result of set web pool attribute that is a collection (string)
+  ansible.windows.win_shell: |
+    Import-Module WebAdministration
+    (Get-ItemProperty -Path "IIS:\AppPools\{{test_iis_webapppool_name}}" -Name recycling.periodicRestart.schedule).Collection | ForEach-Object { $_.value.ToString() }
+  register: collection_change_result
+
+- name: assert results of set web pool attribute that is a collection
+  assert:
+    that:
+    - collection_change is changed
+    - collection_change_result.stdout_lines == [ "01:10:00", "11:10:00" ]
+
+- name: set web pool attribute that is a collection (array)
+  web_app_pool:
+    name: '{{test_iis_webapppool_name}}'
+    state: present
+    attributes:
+      recycling.periodicRestart.schedule: ["00:10:00","10:10:00"]
+  register: collection_change
+
+- name: get result of set web pool attribute that is a collection (array)
   ansible.windows.win_shell: |
     Import-Module WebAdministration
     (Get-ItemProperty -Path "IIS:\AppPools\{{test_iis_webapppool_name}}" -Name recycling.periodicRestart.schedule).Collection | ForEach-Object { $_.value.ToString() }

--- a/tests/integration/targets/web_app_pool/tasks/tests.yml
+++ b/tests/integration/targets/web_app_pool/tasks/tests.yml
@@ -339,7 +339,7 @@
     name: '{{test_iis_webapppool_name}}'
     state: present
     attributes:
-      recycling.periodicRestart.schedule: ["00:10:00","10:10:00"]
+      recycling.periodicRestart.schedule: ["00:10:00", "10:10:00"]
   register: collection_change_check
   check_mode: yes
 
@@ -380,7 +380,7 @@
     name: '{{test_iis_webapppool_name}}'
     state: present
     attributes:
-      recycling.periodicRestart.schedule: ["00:10:00","10:10:00"]
+      recycling.periodicRestart.schedule: ["00:10:00", "10:10:00"]
   register: collection_change
 
 - name: get result of set web pool attribute that is a collection (array)
@@ -400,7 +400,7 @@
     name: '{{test_iis_webapppool_name}}'
     state: present
     attributes:
-      recycling.periodicRestart.schedule: [ "00:10:00", "10:10:00" ]
+      recycling.periodicRestart.schedule: ["00:10:00", "10:10:00"]
   register: collection_change_again
 
 - name: assert results of set web pool attribute that is a collection (idempotent)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the ``recycling.periodicRestart.schedule`` inside Ansible Parameter ``attributes``. The value can be set as an Array like the example in the documentation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #48 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/web_app_pool.ps1

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The existing code allowed to set this parameter using a string containing TimeSpan joined with a ','.
```yaml
- name: Manage a timespan attribute
  microsoft.iis.web_app_pool:
    name: TimespanAppPool
    state: started
    attributes:
      recycling.periodicRestart.time: "00:00:05:00.000000"
      recycling.periodicRestart.schedule: "00:10:00,05:30:00"
      processModel.pingResponseTime: "00:03:00"
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
Now, the modules implementation follows the already described example.
```yaml
- name: Manage a timespan attribute
  microsoft.iis.web_app_pool:
    name: TimespanAppPool
    state: started
    attributes:
      recycling.periodicRestart.time: "00:00:05:00.000000"
      recycling.periodicRestart.schedule: ["00:10:00", "05:30:00"]
      processModel.pingResponseTime: "00:03:00"
```
