### PR TITLE
Update test matrix for new Ansible devel bump

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -69,6 +69,20 @@ stages:
           targets:
             - name: Sanity
               test: sanity
+  - stage: Ansible_2_21
+    displayName: Ansible 2.21
+    dependsOn:
+      - Dependencies
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: "{0}"
+          testFormat: "2.21/{0}"
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Lint
+              test: lint
   - stage: Ansible_2_20
     displayName: Ansible 2.20
     dependsOn:
@@ -81,8 +95,6 @@ stages:
           targets:
             - name: Sanity
               test: sanity
-            - name: Lint
-              test: lint
   - stage: Ansible_2_19
     displayName: Ansible 2.19
     dependsOn:
@@ -161,6 +173,7 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_21
       - Ansible_2_20
       - Ansible_2_19
       - Ansible_2_18


### PR DESCRIPTION
##### SUMMARY
Bumps the versions tested and sanity ignore files now that Ansible devel has been bumped to 2.22.