### PR TITLE
Document PowerShell version support

### DIFF
--- a/plugins/doc_fragments/powershell.py
+++ b/plugins/doc_fragments/powershell.py
@@ -1,0 +1,23 @@
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+
+class ModuleDocFragment:
+
+    # This doc fragment is for PowerShell support information for modules in this collection.
+    DOCUMENTATION = r"""
+attributes:
+  powershell:
+    description:
+      - List of target PowerShell versions specified by O(versions) supported by
+        this module.
+      - Version V(7) without a minor version specified means the V(7.x) versions
+        should be supported by Ansible should work but see O(details) for more
+        information.
+      - PowerShell V(5.1) is supported on Windows only while V(7.x) is
+        cross-platform. See O(platform) for more details on what platforms are
+        supported.
+    support: N/A
+"""

--- a/plugins/modules/virtual_directory.yml
+++ b/plugins/modules/virtual_directory.yml
@@ -56,6 +56,7 @@ DOCUMENTATION:
       type: str
   extends_documentation_fragment:
     - ansible.builtin.action_common_attributes
+    - microsoft.iis.powershell
   attributes:
     check_mode:
       support: full
@@ -64,6 +65,13 @@ DOCUMENTATION:
     platform:
       platforms:
         - windows
+    powershell:
+      details:
+        - This module uses the C(IISAdministration) PowerShell module which is
+          only compatible with Windows PowerShell 5.1, PowerShell 7 is not
+          supported.
+      versions:
+        - '5.1'
   seealso:
     - module: microsoft.iis.virtual_directory_info
     - module: microsoft.iis.web_application

--- a/plugins/modules/virtual_directory_info.yml
+++ b/plugins/modules/virtual_directory_info.yml
@@ -28,6 +28,7 @@ DOCUMENTATION:
       type: str
   extends_documentation_fragment:
     - ansible.builtin.action_common_attributes
+    - microsoft.iis.powershell
   attributes:
     check_mode:
       support: full
@@ -36,6 +37,13 @@ DOCUMENTATION:
     platform:
       platforms:
         - windows
+    powershell:
+      details:
+        - This module uses the C(IISAdministration) PowerShell module which is
+          only compatible with Windows PowerShell 5.1, PowerShell 7 is not
+          supported.
+      versions:
+        - '5.1'
   seealso:
     - module: microsoft.iis.virtual_directory
   author:

--- a/plugins/modules/web_app_pool.yml
+++ b/plugins/modules/web_app_pool.yml
@@ -46,6 +46,7 @@ DOCUMENTATION:
       default: present
   extends_documentation_fragment:
     - ansible.builtin.action_common_attributes
+    - microsoft.iis.powershell
   attributes:
     check_mode:
       support: full
@@ -54,6 +55,13 @@ DOCUMENTATION:
     platform:
       platforms:
         - windows
+    powershell:
+      details:
+        - This module uses the C(IISAdministration) PowerShell module which is
+          only compatible with Windows PowerShell 5.1, PowerShell 7 is not
+          supported.
+      versions:
+        - '5.1'
   seealso:
     - module: microsoft.iis.web_app_pool_info
   author:

--- a/plugins/modules/web_app_pool_info.yml
+++ b/plugins/modules/web_app_pool_info.yml
@@ -18,6 +18,7 @@ DOCUMENTATION:
       required: false
   extends_documentation_fragment:
     - ansible.builtin.action_common_attributes
+    - microsoft.iis.powershell
   attributes:
     check_mode:
       support: full
@@ -26,6 +27,13 @@ DOCUMENTATION:
     platform:
       platforms:
         - windows
+    powershell:
+      details:
+        - This module uses the C(IISAdministration) PowerShell module which is
+          only compatible with Windows PowerShell 5.1, PowerShell 7 is not
+          supported.
+      versions:
+        - '5.1'
   seealso:
     - module: microsoft.iis.web_app_pool
   author:

--- a/plugins/modules/web_application.yml
+++ b/plugins/modules/web_application.yml
@@ -64,6 +64,7 @@ DOCUMENTATION:
       type: str
   extends_documentation_fragment:
     - ansible.builtin.action_common_attributes
+    - microsoft.iis.powershell
   attributes:
     check_mode:
       support: full
@@ -72,6 +73,13 @@ DOCUMENTATION:
     platform:
       platforms:
         - windows
+    powershell:
+      details:
+        - This module uses the C(IISAdministration) PowerShell module which is
+          only compatible with Windows PowerShell 5.1, PowerShell 7 is not
+          supported.
+      versions:
+        - '5.1'
   seealso:
     - module: microsoft.iis.web_application_info
     - module: microsoft.iis.web_app_pool

--- a/plugins/modules/web_application_info.yml
+++ b/plugins/modules/web_application_info.yml
@@ -23,6 +23,7 @@ DOCUMENTATION:
       type: str
   extends_documentation_fragment:
     - ansible.builtin.action_common_attributes
+    - microsoft.iis.powershell
   attributes:
     check_mode:
       support: full
@@ -31,6 +32,13 @@ DOCUMENTATION:
     platform:
       platforms:
         - windows
+    powershell:
+      details:
+        - This module uses the C(IISAdministration) PowerShell module which is
+          only compatible with Windows PowerShell 5.1, PowerShell 7 is not
+          supported.
+      versions:
+        - '5.1'
   seealso:
     - module: microsoft.iis.web_application
     - module: microsoft.iis.website

--- a/plugins/modules/website.yml
+++ b/plugins/modules/website.yml
@@ -173,6 +173,7 @@ DOCUMENTATION:
       choices: [absent, started, stopped, restarted]
   extends_documentation_fragment:
     - ansible.builtin.action_common_attributes
+    - microsoft.iis.powershell
   attributes:
     check_mode:
       support: full
@@ -181,6 +182,13 @@ DOCUMENTATION:
     platform:
       platforms:
         - windows
+    powershell:
+      details:
+        - This module uses the C(IISAdministration) PowerShell module which is
+          only compatible with Windows PowerShell 5.1, PowerShell 7 is not
+          supported.
+      versions:
+        - '5.1'
   seealso:
     - module: microsoft.iis.website_info
     - module: microsoft.iis.web_app_pool

--- a/plugins/modules/website_info.yml
+++ b/plugins/modules/website_info.yml
@@ -18,6 +18,7 @@ DOCUMENTATION:
       required: false
   extends_documentation_fragment:
     - ansible.builtin.action_common_attributes
+    - microsoft.iis.powershell
   attributes:
     check_mode:
       support: full
@@ -26,6 +27,13 @@ DOCUMENTATION:
     platform:
       platforms:
         - windows
+    powershell:
+      details:
+        - This module uses the C(IISAdministration) PowerShell module which is
+          only compatible with Windows PowerShell 5.1, PowerShell 7 is not
+          supported.
+      versions:
+        - '5.1'
   seealso:
     - module: microsoft.iis.website
   author:


### PR DESCRIPTION
##### SUMMARY
Adds documentation for the PowerShell versions supported by the modules in this collection. Currently all modules are WinPS 5.1 only due to their reliance on an older module provided by Microsoft that only works in 5.1

##### ISSUE TYPE
- Docs Pull Request