### PR TITLE
Changed SSL flag detection to be compatible with IIS 10 version 1809 and higher

### DIFF
--- a/changelogs/fragments/website-flags.yml
+++ b/changelogs/fragments/website-flags.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    website_info - Fix logic for determining ``use_ccs`` is set to take into account new SSL flags added in Server 1809
+    or newer - https://github.com/ansible-collections/microsoft.iis/pull/57

--- a/plugins/modules/website_info.ps1
+++ b/plugins/modules/website_info.ps1
@@ -41,15 +41,15 @@ function Get-WebsiteInfo ($name) {
     $bindings_list = @(
         $site_bindings | ForEach-Object {
             $ssl_flags = $_.sslFlags
-            $use_ccs = [math]::Floor($ssl_flags / 2)
-            $use_sni = $ssl_flags % 2
+            $use_ccs = ($ssl_flags -band 2) -gt 0
+            $use_sni = ($ssl_flags -band 1) -gt 0
             $psObject = [PSCustomObject]@{
                 ip = $($_.bindingInformation -split ":")[0]
                 port = [int]$($_.bindingInformation -split ":")[1]
                 hostname = $($_.bindingInformation -split ":")[2]
                 protocol = $_.protocol
-                use_ccs = [bool]$use_ccs
-                use_sni = [bool]$use_sni
+                use_ccs = $use_ccs
+                use_sni = $use_sni
                 certificate_hash = $_.certificateHash
                 certificate_store_name = $_.CertificateStoreName
             }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The current binding parsing of the IIS `sslFlags` attribute into `use_sni` and `use_ccs` was built for an earlier version of IIS and is faulty on more current versions of IIS.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/modules/website_info.ps1`

##### ADDITIONAL INFORMATION
The current attributes listed on the [Microsoft website](https://learn.microsoft.com/en-us/iis/configuration/system.applicationhost/sites/site/bindings/binding#attributes) include all the SSL flags that are supported on Windows Server 2019 or later.  With the way the current parsing is written for `use_ccs`, if any flags with a value greater than 2 are set, the `use_ccs` flag will parse as `true`.  Example: if Disable HTTP/2 is set but CCS is not, the flags will be set as `0b0000100` and `[math]::Floor($ssl_flags / 2)` will be greater than 0, which means it will evaluate as `true` when cast to a bool.

Example here on a server without the CCS role even installed, but Disable HTTP/2 set, but `use_ccs` evaluates to `true`:

<img width="527" height="419" alt="Screenshot 2026-06-03 101141" src="https://github.com/user-attachments/assets/f1b82cd5-2ef0-483b-b60c-c242c049b03c" />

```yaml
ok: [server] =>
    iis_website_info:
        changed: false
        exists: true
        failed: false
        site:
        -   application_pool: DefaultAppPool
            bindings:
            -   certificate_hash: <redacted>
                certificate_store_name: My
                hostname: ''
                ip: '*'
                port: 443
                protocol: https
                use_ccs: true
                use_sni: false
            name: Default Web Site
            physical_path: '%SystemDrive%\inetpub\wwwroot'
            site_id: 1
            state: Started
```

With this change, `use_ccs` evaluates as `false`:

```yaml
ok: [server] =>
    iis_website_info:
        changed: false
        exists: true
        failed: false
        site:
        -   application_pool: DefaultAppPool
            bindings:
            -   certificate_hash: <redacted>
                certificate_store_name: My
                hostname: ''
                ip: '*'
                port: 443
                protocol: https
                use_ccs: false
                use_sni: false
            name: Default Web Site
            physical_path: '%SystemDrive%\inetpub\wwwroot'
            site_id: 1
            state: Started
```