### PR TITLE
Fix missing changed status when updating certificate on existing binding

### DIFF
--- a/changelogs/fragments/fix-website-cert-changed.yaml
+++ b/changelogs/fragments/fix-website-cert-changed.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - website - fix missing ``changed`` status when updating the certificate onan existing HTTPS binding via ``bindings.add`` (https://github.com/ansible-collections/microsoft.iis/pull/59).
+  - website - fix ``changed`` not set on cert update for existing binding via ``bindings.add`` (https://github.com/ansible-collections/microsoft.iis/pull/59).

--- a/changelogs/fragments/fix-website-cert-changed.yaml
+++ b/changelogs/fragments/fix-website-cert-changed.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - website - fix missing ``changed`` status when updating the certificate onan existing HTTPS binding via ``bindings.add`` (https://github.com/ansible-collections/microsoft.iis/pull/59).

--- a/plugins/modules/website.ps1
+++ b/plugins/modules/website.ps1
@@ -273,8 +273,11 @@ Try {
                     $module.Result.changed = $true
                 }
                 If ($user_edit.certificate_hash) {
-                    $edit_binding = Get-WebBinding -Name $site.Name -IPAddress $user_edit.ip -Port $user_edit.port -HostHeader $user_edit.hostname
-                    $edit_binding.AddSslCertificate($user_edit.certificate_hash, $user_edit.certificate_store_name)
+                    if ($site_edit.certificateHash -ne $user_edit.certificate_hash -or $site_edit.CertificateStoreName -ne $user_edit.certificate_store_name) {
+                        $edit_binding = Get-WebBinding -Name $site.Name -IPAddress $user_edit.ip -Port $user_edit.port -HostHeader $user_edit.hostname
+                        $edit_binding.AddSslCertificate($user_edit.certificate_hash, $user_edit.certificate_store_name)
+                        $module.Result.changed = $true
+                    }
                 }
             }
             $toRemove | ForEach-Object {


### PR DESCRIPTION
##### SUMMARY
When `bindings.add` matched an existing binding (by `ip:port:hostname`), the module called
`AddSslCertificate` unconditionally without comparing the existing `certificateHash` or
`CertificateStoreName`, and never set `changed = true`. Supplying a new thumbprint would
appear idempotent (`ok`) even though the binding was being updated on every run, making it
impossible to tell from Ansible output whether a certificate rotation had taken effect.

The protocol and `sslFlags` checks in the same block already follow the correct pattern
(compare → update → set `changed`). This fix applies the same pattern to `certificate_hash`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
website

##### ADDITIONAL INFORMATION
Before and after running with a new certificate thumbprint:

```paste below
# Before fix - new thumbprint supplied, binding updated but reported ok
TASK [Bind certificate to IIS] *************************************************
ok: [host] => (item={'name': 'Default Web Site', 'protocol': 'https', ...})

# After fix - new thumbprint supplied, correctly reports changed
TASK [Bind certificate to IIS] *************************************************
changed: [host] => (item={'name': 'Default Web Site', 'protocol': 'https', ...})

# After fix - same thumbprint on second run, correctly reports ok
TASK [Bind certificate to IIS] *************************************************
ok: [host] => (item={'name': 'Default Web Site', 'protocol': 'https', ...})
```