### PR TITLE
Fix/ci container python 313

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
   - name: fetchDepth
     value: 0
   - name: defaultContainer
-    value: quay.io/ansible/azure-pipelines-test-container:7.0.0
+    value: quay.io/ansible/azure-pipelines-test-container:8.0.0
 
 pool: Standard
 

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -123,6 +123,9 @@ stages:
     displayName: Ansible 2.17
     dependsOn:
       - Dependencies
+    variables:
+      - name: defaultContainer
+        value: quay.io/ansible/azure-pipelines-test-container:7.0.0
     jobs:
       - template: templates/matrix.yml
         parameters:
@@ -135,6 +138,9 @@ stages:
     displayName: Ansible 2.16
     dependsOn:
       - Dependencies
+    variables:
+      - name: defaultContainer
+        value: quay.io/ansible/azure-pipelines-test-container:7.0.0
     jobs:
       - template: templates/matrix.yml
         parameters:


### PR DESCRIPTION
##### SUMMARY
Bumps the default CI container from `quay.io/ansible/azure-pipelines-test-container:7.0.0`
to `8.0.0`. The `7.0.0` image ships Python 3.12.3, which is no longer compatible with
`ansible-core devel` (now requires Python >=3.13), causing all devel sanity and integration
jobs to fail before any tests run.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.azure-pipelines/azure-pipelines.yml

##### ADDITIONAL INFORMATION
Failure seen on all devel jobs prior to this fix:

```
ERROR: Package 'ansible-core' requires a different Python: 3.12.3 not in '>=3.13'
Command '@*' failed 3 times!
Bash exited with code '1'
```
