### PR TITLE
Don't include docsite link as it isn't available in PRs

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -27,11 +27,6 @@ jobs:
       init-html-short-title: Microsoft.IIS Collection Docs
       init-extra-html-theme-options: |
         documentation_home_url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/branch/main/
-      render-file-line: >-
-        > * `$<status>`
-        [$<path_tail>]
-        (https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr/${{ github.event.number }}/$<path_tail>)
-
   comment:
     permissions:
       pull-requests: write


### PR DESCRIPTION
##### SUMMARY
The template used had a repo that would publish the docs to a temporary location for this repo but as we don't do that here we just make sure the rendered files that have been changed are just the filename and not a broken link (default value).

##### ISSUE TYPE
- Docs Pull Request