### PR TITLE
Non-HTTP/HTTPS site bindings are not able to be changed, but are attempted to be removed

### DIFF
--- a/plugins/modules/website.ps1
+++ b/plugins/modules/website.ps1
@@ -216,8 +216,7 @@ Try {
         }
         # Add Remove or Set bindings if needed
         if ( $null -ne $bindings.set -or $bindings.add.Count -gt 0 -or $bindings.remove.Count -gt 0 ) {
-            $site_bindings = (Get-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)").Bindings.Collection |
-                Where-Object { $_.protocol -in $binding_options.options.protocol.choices }
+            $site_bindings = (Get-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)").Bindings.Collection | Where-Object { $_.protocol -in $binding_options.options.protocol.choices }
             $toAdd = @()
             $toEdit = @()
             $toRemove = @()

--- a/plugins/modules/website.ps1
+++ b/plugins/modules/website.ps1
@@ -216,8 +216,7 @@ Try {
         }
         # Add Remove or Set bindings if needed
         if ( $null -ne $bindings.set -or $bindings.add.Count -gt 0 -or $bindings.remove.Count -gt 0 ) {
-            $site_bindings = Get-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)" | Select-Object -ExpandProperty Bindings |
-                Select-Object -ExpandProperty Collection | Where-Object { $_.protocol -in $binding_options.options.protocol.choices }
+            $site_bindings = Get-WebBinding -Name $site.Name | Where-Object { $_.protocol -in $binding_options.options.protocol.choices }
             $toAdd = @()
             $toEdit = @()
             $toRemove = @()

--- a/plugins/modules/website.ps1
+++ b/plugins/modules/website.ps1
@@ -216,7 +216,8 @@ Try {
         }
         # Add Remove or Set bindings if needed
         if ( $null -ne $bindings.set -or $bindings.add.Count -gt 0 -or $bindings.remove.Count -gt 0 ) {
-            $site_bindings = (Get-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)").Bindings.Collection
+            $site_bindings = (Get-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)").Bindings.Collection |
+                Where-Object { $_.protocol -in $binding_options.options.protocol.choices }
             $toAdd = @()
             $toEdit = @()
             $toRemove = @()

--- a/plugins/modules/website.ps1
+++ b/plugins/modules/website.ps1
@@ -216,7 +216,8 @@ Try {
         }
         # Add Remove or Set bindings if needed
         if ( $null -ne $bindings.set -or $bindings.add.Count -gt 0 -or $bindings.remove.Count -gt 0 ) {
-            $site_bindings = (Get-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)").Bindings.Collection
+            $site_bindings = Get-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)" | Select-Object -ExpandProperty Bindings |
+                Select-Object -ExpandProperty Collection | Where-Object { $_.protocol -in $binding_options.options.protocol.choices }
             $toAdd = @()
             $toEdit = @()
             $toRemove = @()

--- a/plugins/modules/website.ps1
+++ b/plugins/modules/website.ps1
@@ -216,7 +216,8 @@ Try {
         }
         # Add Remove or Set bindings if needed
         if ( $null -ne $bindings.set -or $bindings.add.Count -gt 0 -or $bindings.remove.Count -gt 0 ) {
-            $site_bindings = Get-WebBinding -Name $site.Name | Where-Object { $_.protocol -in $binding_options.options.protocol.choices }
+            $site_bindings = (Get-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)").Bindings.Collection |
+                Where-Object { $_.protocol -in $binding_options.options.protocol.choices }
             $toAdd = @()
             $toEdit = @()
             $toRemove = @()

--- a/plugins/modules/website.ps1
+++ b/plugins/modules/website.ps1
@@ -216,7 +216,7 @@ Try {
         }
         # Add Remove or Set bindings if needed
         if ( $null -ne $bindings.set -or $bindings.add.Count -gt 0 -or $bindings.remove.Count -gt 0 ) {
-            $site_bindings = (Get-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)").Bindings.Collection | Where-Object { $_.protocol -in $binding_options.options.protocol.choices }
+            $site_bindings = (Get-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)").Bindings.Collection
             $toAdd = @()
             $toEdit = @()
             $toRemove = @()

--- a/plugins/modules/website.ps1
+++ b/plugins/modules/website.ps1
@@ -253,7 +253,7 @@ Try {
             $toEdit | ForEach-Object {
                 $user_edit = $_
                 $site_edit = $site_bindings | Where-Object { $_.bindingInformation -eq "$($user_edit.ip):$($user_edit.port):$($user_edit.hostname)" }
-                $binding_index = $site_bindings.IndexOf($site_edit)
+                $edit_binding = Get-WebBinding -Name $site.Name -IPAddress $user_edit.ip -Port $user_edit.port -HostHeader $user_edit.hostname
                 # Get existing use_sni value from site if null
                 if ($null -eq $user_edit.use_sni) {
                     $user_edit.use_sni = $site_edit.sslFlags % 2
@@ -264,18 +264,15 @@ Try {
                 }
                 $ssl_flags = Get-SSLFlagFromBinding -BindingInfo $user_edit
                 if ($site_edit.protocol -ne $user_edit.protocol) {
-                    Set-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)" -Name "Bindings.Collection[$binding_index].protocol"`
-                        -value $user_edit.protocol -WhatIf:$check_mode
+                    $edit_binding | Set-WebBinding -Name $site.Name -PropertyName "protocol" -Value $user_edit.protocol -WhatIf:$check_mode
                     $module.Result.changed = $true
                 }
                 if ($site_edit.sslFlags -ne $ssl_flags) {
-                    Set-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)" -Name "Bindings.Collection[$binding_index].sslFlags"`
-                        -value $ssl_flags -WhatIf:$check_mode
+                    $edit_binding | Set-WebBinding -Name $site.Name -PropertyName "sslFlags" -Value $ssl_flags -WhatIf:$check_mode
                     $module.Result.changed = $true
                 }
                 If ($user_edit.certificate_hash) {
                     if ($site_edit.certificateHash -ne $user_edit.certificate_hash -or $site_edit.CertificateStoreName -ne $user_edit.certificate_store_name) {
-                        $edit_binding = Get-WebBinding -Name $site.Name -IPAddress $user_edit.ip -Port $user_edit.port -HostHeader $user_edit.hostname
                         $edit_binding.AddSslCertificate($user_edit.certificate_hash, $user_edit.certificate_store_name)
                         $module.Result.changed = $true
                     }


### PR DESCRIPTION
##### SUMMARY

Non-HTTP/HTTPS site bindings, such as `net.tcp`, are not able to be changed using the `website` module, but the module attempts to remove them, since they cannot be listed in the list of bindings to set.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/modules/website.ps1`

##### ADDITIONAL INFORMATION

I have an IIS server running Exchange.  It uses several types of protocols: `http`, `https`, `net.tcp`, `net.pipe`, and others.  When trying to configure bindings, the [only options available are `http` and `https`](https://github.com/ansible-collections/microsoft.iis/blob/e4c6186dbdebce412ab73e203e48539393e04dbd/plugins/modules/website.ps1#L16).  Currently the way that existing site bindings are populated is [using a method that will list all bindings, regardless of protocol](https://github.com/ansible-collections/microsoft.iis/blob/e4c6186dbdebce412ab73e203e48539393e04dbd/plugins/modules/website.ps1#L219).  Example here:

```pwsh
> (Get-ItemProperty -LiteralPath "IIS:\Sites\$($site.Name)").Bindings.Collection
protocol        bindingInformation sslFlags
--------        ------------------ --------
http            *:80:                     0
net.tcp         808:*                     0
net.msmq        localhost                 0
msmq.formatname localhost                 0
net.pipe        *                         0
http            127.0.0.1:80:             0
https           *:443:                    0
https           127.0.0.1:443:            0
```

Since `net.tcp` and the other unsupported protocols cannot be added to the bindings list in a task, they will get added to the [`$toRemove` list](https://github.com/ansible-collections/microsoft.iis/blob/e4c6186dbdebce412ab73e203e48539393e04dbd/plugins/modules/website.ps1#L228) and 

Here is an example task:

```yaml
- name: "Re-create HTTPS bindings"
  microsoft.iis.website:
    name: "Default Web Site"
    bindings:
      set:
        -   certificate_hash: ''
            certificate_store_name: ''
            hostname: myhost.example.com
            ip: '*'
            port: 80
            protocol: http
            use_ccs: false
            use_sni: false
        -   certificate_hash: 0C03CBC3D77D62E4694A6349409C219E9D8DA5E5
            certificate_store_name: My
            hostname: myhost.example.com
            ip: '*'
            port: 443
            protocol: https
            use_ccs: false
            use_sni: false
    state: restarted
```

Additionally, since the way the bindings filtered into `$toRemove` are removed does not include a protocol and only works off of the `bindingInformation`, this can remove the HTTP and HTTPS bindings that were just modified.

~~This can be fixed by modifying the way that existing site bindings are populated so that it filters the bindings by only the supported protocols.  Alternatively, it could be changed to use the `Get-WebBinding` cmdlet instead, but that will only pull up three protocols: HTTP, HTTPS, and FTP.  There may be another way to edit the `net.tcp` and other protocols if needed, but they're not available using that method.~~

This does mean that the bindings list will not perfectly reflect the list of bindings passed into `set:`, but since the module does not support other protocols at this time (e.g. FTP is feature requested in #42), the options are either to remove configurations we can't modify or ignore them—this is the "ignore them until they're supported" option.

Edit: It turns out that there's an issue that the tests have hung up on that means that the [IndexOf at line 255](https://github.com/ansible-collections/microsoft.iis/blob/e4c6186dbdebce412ab73e203e48539393e04dbd/plugins/modules/website.ps1#L255) appears to be invalid?  I can't figure out why, so I've converted to using `Get-WebBinding` and `Set-WebBinding` because it can edit the correct binding without having to use an indexing function like `Set-ItemProperty` requires.